### PR TITLE
Starting point for implementation of key field

### DIFF
--- a/autocomplete-client.coffee
+++ b/autocomplete-client.coffee
@@ -134,6 +134,9 @@ class @AutoComplete
     startpos = @element.selectionStart
     val = @getText().substring(0, startpos)
 
+    #clear the key
+	@removeKey()
+	
     ###
       Matching on multiple expressions.
       We always go from a matched state to an unmatched one
@@ -256,6 +259,9 @@ class @AutoComplete
       # Single-field replacement: replace whole field
       @setText(replacement)
 
+	  # if we have a key field, set it onto the element
+	  @setKey(getField(doc, rule.key)) if rule.key
+	  
       # Field retains focus, but list is hidden unless another key is pressed
       # Must be deferred or onKeyUp will trigger and match again
       # TODO this is a hack; see above
@@ -292,6 +298,12 @@ class @AutoComplete
       @$element.val(text)
     else
       @$element.html(text)
+
+    setKey: (text) ->
+	    @$element.prop('key',text)
+		
+    removeKey: ->
+	    @$element.removeProp('key')
 
   ###
     Rendering functions

--- a/autocomplete-client.coffee
+++ b/autocomplete-client.coffee
@@ -299,11 +299,11 @@ class @AutoComplete
     else
       @$element.html(text)
 
-    setKey: (text) ->
-	    @$element.prop('key',text)
+  setKey: (text) ->
+    @$element.prop('key',text)
 		
-    removeKey: ->
-	    @$element.removeProp('key')
+  removeKey: ->
+    @$element.removeProp('key')
 
   ###
     Rendering functions

--- a/autocomplete-client.coffee
+++ b/autocomplete-client.coffee
@@ -135,7 +135,7 @@ class @AutoComplete
     val = @getText().substring(0, startpos)
 
     #clear the key
-	@removeKey()
+    @removeKey()
 	
     ###
       Matching on multiple expressions.
@@ -259,8 +259,8 @@ class @AutoComplete
       # Single-field replacement: replace whole field
       @setText(replacement)
 
-	  # if we have a key field, set it onto the element
-	  @setKey(getField(doc, rule.key)) if rule.key
+      # if we have a key field, set it onto the element
+      @setKey(getField(doc, rule.key)) if rule.key
 	  
       # Field retains focus, but list is hidden unless another key is pressed
       # Must be deferred or onKeyUp will trigger and match again

--- a/templates.coffee
+++ b/templates.coffee
@@ -21,10 +21,10 @@ autocompleteHelpers = {
     this.onViewReady ->
       ac.element = this.parentView.firstNode()
       ac.$element = $(ac.element)
-	  if (Template.parentData(0).initialKey)
-	      doc = ac.rules[0].collection.findOne(Template.parentData(0).initialKey)
-		  ac.setText(doc[ac.rules[0].field])
-		  ac.setKey(doc[ac.rules[0].key])
+      if (Template.parentData(0).initialKey)
+          doc = ac.rules[0].collection.findOne(Template.parentData(0).initialKey)
+          ac.setText(doc[ac.rules[0].field])
+          ac.setKey(doc[ac.rules[0].key])
 
     return Blaze.With(ac, -> Template._autocompleteContainer)
   )

--- a/templates.coffee
+++ b/templates.coffee
@@ -8,7 +8,7 @@ acEvents =
 Template.inputAutocomplete.events(acEvents)
 Template.textareaAutocomplete.events(acEvents)
 
-attributes = -> _.omit(@, 'settings') # Render all but the settings parameter
+attributes = -> _.omit(@, ['settings', 'initialKey']) # Render all but the settings and initialKey parameters
 
 autocompleteHelpers = {
   attributes,
@@ -21,6 +21,10 @@ autocompleteHelpers = {
     this.onViewReady ->
       ac.element = this.parentView.firstNode()
       ac.$element = $(ac.element)
+	  if (Template.parentData(0).initialKey)
+	      doc = ac.rules[0].collection.findOne(Template.parentData(0).initialKey)
+		  ac.setText(doc[ac.rules[0].field])
+		  ac.setKey(doc[ac.rules[0].key])
 
     return Blaze.With(ac, -> Template._autocompleteContainer)
   )


### PR DESCRIPTION
I post this not as a proposed robust solution, but rather as a starting point for further work.  I've implemented a simple version of a "key" field in the autocomplete.

What it does:
* Allows a "key" attribute in the settings which specifies a key field in the collection
* Whenever an item is selected in the list, there is a 'key' property added to the input which contains the key value that matches the selected item
* As you type in the input, the key is cleared to ensure it only exists if an item in the collection was selected
* The template can then have an "initialKey" parameter passed in, and the matching item from the collection will be pre-populated into the input

Where it falls down (among other places, I'm sure):
* I've hardcoded the selection to tie to rules[0]... worked for my use case, but obviously not a good solution
* I haven't fully thought through how this should work for any scenario other than whole-field replacement

Just figured I'd share since I made it this far...