### PR TITLE
Extended the server rules to use 'subscriptionParams' object. This ob…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Template.foo.helpers({
 - `token`: (optional) What character should trigger this rule. Leave blank for whole-field behavior (see below).
 - `collection`: What collection should be used to match for this rule. Must be a `Mongo.Collection` for client-side collections, or a string for remote collections (available in `global` on the server.)
 - `subscription`: A custom subscription for server-side search; see below.
+- `subscriptionParams` - additional information required by the publication function, i.e. providing additional data for accessing external APIs (like token, etc)
 - `template`: The template that should be used to render each list item.
 - `filter`: (optional) An object that will be merged with the autocomplete selector to limit the results to more specific documents in the collection.
 - `sort`: (default `false`) Whether to sort the results before applying the limit. For good performance on large collections, this should be turned on only for server-side searches where an index can be used.

--- a/autocomplete-client.coffee
+++ b/autocomplete-client.coffee
@@ -102,8 +102,9 @@ class @AutoComplete
       # console.debug 'Subscribing to <%s> in <%s>.<%s>', filter, rule.collection, rule.field
       @setLoaded(false)
       subName = rule.subscription || "autocomplete-recordset"
+      subscriptionParams = rule.subscriptionParams || rule.collection
       @sub = Meteor.subscribe(subName,
-        selector, options, rule.collection, => @setLoaded(true))
+        selector, options, subscriptionParams, => @setLoaded(true))
 
   teardown: ->
     # Stop the reactive computation we started for this autocomplete instance


### PR DESCRIPTION
Extended the server rules to use 'subscriptionParams' object. This object may be provided in the settings->rule schema and enable sending the server subscription additional args within this object. In case a collection name is sent it will still send it (for backward compatability). However, in most of the production apps, a server subscription will be used, and it will enable sending additional args to the server (like token, etc) without breaking the API
